### PR TITLE
FIX l10n_it_fiscalcode: correctly test onchange

### DIFF
--- a/l10n_it_fiscalcode/model/res_partner.py
+++ b/l10n_it_fiscalcode/model/res_partner.py
@@ -66,7 +66,6 @@ class ResPartner(models.Model):
         have different fiscal code.
         A proper warning is displayed.
         """
-#        set_trace()
         self.ensure_one()
 
         if not self.fiscalcode:
@@ -76,50 +75,22 @@ class ResPartner(models.Model):
         same_fiscalcode_partners = self.env['res.partner'].search([
             ('fiscalcode', '=', self.fiscalcode),
             ('fiscalcode', '!=', False),
-            ('company_id', '=', self.company_id.id),
             ])
         if not same_fiscalcode_partners:
             # there is no partner with same fiscalcode.
             # Safe condition. return
-            return {}
-
-        if isinstance(self.id, models.NewId) and not self.parent_id:
-            # new record with no parent BUT there are other partners
-            # with same fiscal code
-            is_fc_present = True
+            result = {}
         else:
-            # new or old record with parent
-            # get first parent to start searching
-            parent = self
-            while parent.parent_id:
-                parent = parent.parent_id
-            # all partners in our family tree
-            related_partners = self.env['res.partner'].search([
-                ('id', 'child_of', parent.id),
-                ('company_id', '=', self.company_id.id),
-                ])
-            # any partner with same fiscal code OUT of our family tree ?
-            is_fc_present = self.env['res.partner'].search([
-                ('id', 'in', same_fiscalcode_partners.ids),
-                ('id', 'not in', related_partners.ids),
-                ('company_id', '=', self.company_id.id),
-                ])
-
-        if is_fc_present:
             title = _('Partner fiscal code is not unique')
             message = _('WARNING:\n'
-                        'Partner fiscal code must be unique per'
-                        ' company except for partner with'
-                        ' parent/child relationship.'
+                        'Partner fiscal code should be unique.'
                         ' Partners with same fiscal code'
-                        ' and not related, are:\n %s!') % (
+                        ' are:\n %s!') % (
                             ', '.join(x.name for x in
                                       same_fiscalcode_partners))
             result = {
                 'warning': {'title': title,
                             'message': message, }, }
-        else:
-            result = {}
         return result
 
     @api.multi

--- a/l10n_it_fiscalcode/tests/test_partner.py
+++ b/l10n_it_fiscalcode/tests/test_partner.py
@@ -162,16 +162,9 @@ class TestPartner(TransactionCase):
                   'is_company': False,
                   'is_soletrader': True,
                   'fiscalcode': u'BNZVCN32S10E573Z', }
-        # Retrieve the onchange specifications
-        specs = partner._onchange_spec()
-        # Get the result of the onchange method for is_company field:
-        updates = partner.onchange(values, ['is_company'], specs)
-        # value  is a dictionary of newly computed field values.
-        # This dictionary only features keys that are in the values parameter
-        # passed to onchange().
-        new_values = updates.get('value', {})
-        # check values computed by the onchange.
-        self.assertEqual(new_values['is_soletrader'], False)
+        partner = partner.create(values)
+        partner.onchange_iscompany()
+        self.assertEqual(partner.is_soletrader, False)
 
     def test_partner_onchange_fiscalcode(self):
         """ Test onchange method when an existing ficsalcode
@@ -180,17 +173,14 @@ class TestPartner(TransactionCase):
         """
         # Get an empty recordset
         partner = self.env['res.partner']
-        # Retrieve the onchange specifications
-        specs = partner._onchange_spec()
 
         # create first partner with normal fiscalcode for private citizen
-        parent = self.env['res.partner'].create(
+        parent = partner.create(
             {'name': u'Test-e1 Private Italian Citizen',
              'email': u"foo@gmail.com",
              'is_company': True,
              'is_soletrader': True,
              'fiscalcode': u'BNZVCN32S10E573Z', })
-#        test1=self.env['res.partner'].search([('fiscalcode','=','BNZVCN32S10E573Z')])
 
         # Prepare the values to create a child record with same fiscalcode
         values = {'name': u'OnChange Test-e2',
@@ -200,14 +190,11 @@ class TestPartner(TransactionCase):
                   'parent_id': parent.id,
                   'fiscalcode': u'BNZVCN32S10E573Z', }
 
-        # Get the result of the onchange method for fiscalcode field:
-        self.env.invalidate_all()
-        result = partner.onchange(values, ['fiscalcode'], specs)
+        partner = partner.new(values)
+        result = partner.onchange_fiscalcode()
         # warning: This is a dictionary containing a warning message
         # that the web client will display to the user
         warning = result.get('warning', {})
+        self.assertEqual(
+            result['warning']['title'], u'Partner fiscal code is not unique')
         # check onchange method produced NO warning
-
-        # final assert test removed beacause of ORM bug of test module
-        # self.assertTrue(warning)
-        self.assertTrue(warning == warning)


### PR DESCRIPTION
@Giuliano69 Con queste modifiche intendo mostrare come testare agevolmente gli onchange.

In questo momento, il risultato di ```onchange_fiscalcode``` è comunque un dizionario vuoto, perchè la ricerca effettuata in ```onchange_fiscalcode``` penso sia sbagliata: ```same_fiscalcode_partners.ids``` e ```related_partners.ids``` contengono lo stesso partner, quello corrente, e quindi ```is_fc_present``` è un recordset vuoto.

Ma a parte questa ricerca, come mai ```Partner fiscal code must be unique per company except for partner with parent/child relationship```? L'unicità, se la vogliamo controllare, dovrebbe essere indipendente dalla parentela.
Puoi dirmi un esempio in cui vogliamo accettare nel sistema 2 partner con lo stesso codice fiscale?

Grazie